### PR TITLE
Update Python and libstempo requirements to match pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,19 +11,19 @@ source:
   sha256: 2577e2e84171ce25d1c490604c2ad7e5ea0ec58b5c838a45474b98e78d73e08c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7,<3.11
+    - python >=3.8,<3.13
   run:
-    - python >=3.7,<3.11
+    - python >=3.8,<3.13
     - ephem >=3.7.6.0
     - healpy >=1.14.0
-    - libstempo >=2.4.0
+    - libstempo >=2.4.4
     - numpy >=1.16.3
     - pint-pulsar >=0.8.3
     - scikit-sparse >=0.4.5


### PR DESCRIPTION
Fixes #12. This updates the version Python version requirement to `python >=3.8,<3.13` (from `python >=3.7,<3.11`) to match the requirement in `pip`.

I also changed the `libstempo` version requirement to `libstempo >=2.4.4` (from `libstempo >= 2.4.0`) for the same reason.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
